### PR TITLE
Add pandoc LaTeX resume template and just resume export command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,4 @@ cython_debug/
 
 # Removes local testing directory
 output/
+resume.pdf

--- a/Justfile
+++ b/Justfile
@@ -1,12 +1,14 @@
+# Windows Variables
+export MSYS_NO_PATHCONV := "1"
+
 # Variables
 PELICAN := "pelican"
 PELICANOPTS := ""
-BASEDIR := invocation_directory()
-INPUTDIR := "{{BASEDIR}}/content"
-OUTPUTDIR := "{{BASEDIR}}/output"
-PUBLISHDIR := "{{BASEDIR}}/docs"
-CONFFILE := "{{BASEDIR}}/pelicanconf.py"
-PUBLISHCONF := "{{BASEDIR}}/publishconf.py"
+INPUTDIR := "content"
+OUTPUTDIR := "output"
+PUBLISHDIR := "docs"
+CONFFILE := "pelicanconf.py"
+PUBLISHCONF := "publishconf.py"
 CNAME := "noelmiller.dev"
 
 help:
@@ -17,6 +19,7 @@ help:
     @echo "  just clean           Remove generated files"
     @echo "  just post            Run container to create a post"
     @echo "  just run             Run container with devserver"
+    @echo "  just resume          Export the resume page to a PDF via pandoc"
     @echo ""
     @echo "Usage (Inside the Container):"
     @echo "  just create-post     Create new post with template"
@@ -39,13 +42,16 @@ post-docker:
     docker run --rm -it --volume .:/app -p 8000:8000 noelmiller.dev:latest create-post
 
 run:
-    podman run --init --rm -it --volume .:/app:Z -p 8000:8000 noelmiller.dev:latest devserver
+    -podman run --init --rm -it --volume .:/app:Z -p 8000:8000 noelmiller.dev:latest devserver
 
 run-docker:
     docker run --init --rm -it --volume .:/app -p 8000:8000 noelmiller.dev:latest devserver
 
 create-post:
     python create_post.py
+
+resume:
+    read -p "Phone number: " phone; sed -e '1d' -e 's/<!--//' -e 's/-->//' -e "s/\[Insert Phone Number Here\]/$phone/" content/pages/resume.md | pandoc --from markdown --template=templates/resume.latex --pdf-engine=pdflatex -o resume.pdf
 
 devserver:
     "{{PELICAN}}" -lr "{{INPUTDIR}}" -o "{{OUTPUTDIR}}" -s "{{CONFFILE}}" -b 0.0.0.0 {{PELICANOPTS}}

--- a/content/pages/resume.md
+++ b/content/pages/resume.md
@@ -66,7 +66,7 @@ April 2025 - November 2025 (Volunteer)
 
 [Universal Blue](https://universal-blue.org)
 
-February 2023 - 2026 (Volunteer)
+February 2023 - July 2026 (Volunteer)
 
 - Engage with the community to understand their needs and desires for the project
 - Manage the project roadmap and ensure that the project is on track to meet its goals

--- a/content/pages/resume.md
+++ b/content/pages/resume.md
@@ -1,15 +1,11 @@
 Title: Resume
 
-<!---
+<!--
 # Noel Miller
 
 **IT Consultant**
 
-Email: [INSERT EMAIL HERE]
-
-Phone: [INSERT PHONE NUMBER HERE]
-
-[LinkedIn](https://www.linkedin.com/in/noel-miller-533909113/) | [GitHub](https://github.com/noelmiller) | [Blog](https://noelmiller.dev)
+noel@noelmiller.dev | [Insert Phone Number Here] | [LinkedIn](https://www.linkedin.com/in/noel-miller-533909113/) | [GitHub](https://github.com/noelmiller) | [Blog](https://noelmiller.dev)
 -->
 
 ### Introduction
@@ -24,9 +20,7 @@ I am a strong proponent of continuous learning to keep my skills sharp in an eve
 
 ### Experience
 
----
-
-**Ansible Dedicated Operations Technical Account Manager**
+**Dedicated Operations Technical Account Manager**
 
 [Red Hat](https://www.redhat.com)
 
@@ -42,15 +36,13 @@ August 2023 - Present
 - Contribute to the development of best practices, knowledge articles, and other technical documentation
 - Participate in the development and delivery of training and enablement programs for customers and partners
 - Contribute to the development and execution of customer success plans
-- Hands-on support with clients to help them implement the Ansible Automation Platform and other Red Hat solutions
-
----
+- Hands-on support with clients to help them implement the Ansible Automation Platform, Red Hat IDM, Red Hat Openshift, and RHEL Platform
 
 **Core Maintainer**
 
 [Bazzite](https://bazzite.gg)
 
-February 2023 - Present (Volunteer)
+February 2023 - July 2026 (Volunteer)
 
 - Engage with the community to understand their needs and desires for the project
 - Coordinate with other contributors to ensure that the project is moving forward
@@ -61,8 +53,6 @@ February 2023 - Present (Volunteer)
 - Contribute to the development of best practices, knowledge articles, and other technical documentation
 - Provide support to the community through forums, social media, and other channels
 
----
-
 **Podcast Host**
 
 [Fedora Podcast](https://podcast.fedoraproject.org)
@@ -72,13 +62,11 @@ April 2025 - November 2025 (Volunteer)
 - Co-host the Fedora Podcast, a long-running podcast that covers all things Fedora
 - Assist with the production of the show, including editing and publishing episodes
 
----
-
 **Core Contributor**
 
 [Universal Blue](https://universal-blue.org)
 
-February 2023 - Present (Volunteer)
+February 2023 - 2026 (Volunteer)
 
 - Engage with the community to understand their needs and desires for the project
 - Manage the project roadmap and ensure that the project is on track to meet its goals
@@ -88,8 +76,6 @@ February 2023 - Present (Volunteer)
 - Develop and deliver technical presentations and demonstrations to the community (see [here](https://noelmiller.dev/pages/media) for my media appearances)
 - Provide feedback to the project leadership on community requirements and issues
 - Contribute to the development of best practices, knowledge articles, and other technical documentation
-
----
 
 **Systems Engineer**
 
@@ -105,8 +91,6 @@ July 2022 - August 2023
 - Assisted with processes surrounding Azure DevOps to start building pipelines and processes for infrastructure deployments
 - Executed the migration of several workloads from Oracle Linux 7 to RHEL 8
 
----
-
 **Systems Administrator**
 
 [Whizkids Tech](https://whizkids.tech)
@@ -121,8 +105,6 @@ August 2021 - July 2022
 - Create PowerShell and ConnectWise Automate scripts to automate the deployment of software on workstations and servers
 - Configure, deploy, and manage Storagecraft backup solutions (both local and cloud)
 
----
-
 **IT Consultant**
 
 [Inside Edge Commercial Interior Services](https://iecis.com/)
@@ -133,8 +115,6 @@ December 2020 - August 2021
 - Document work inside Jira for issues worked
 - Write documentation for manual processes
 - Provided expertise and suggestions for projects and other changes needed to keep infrastructure up to date and secure
-
----
 
 **Service Reliability Engineer**
 
@@ -147,8 +127,6 @@ September 2020 - December 2020
 - Write documentation for manual processes
 - Work with the team on custom software implementations with the development team
 - Utilize version control (Git) to document scripts and fix bugs in scripts
-
----
 
 **Managed Linux Server Engineer**
 
@@ -163,8 +141,6 @@ November 2019 - September 2020
 - Assist with other client environments as needed (Windows or Linux)
 - Collaborate with other departments, including account management, to ensure we provide excellent service
 - Document troubleshooting processes to ensure we have a good baseline for automation and for assisting lower level engineers with troubleshooting
-
----
 
 **Systems Engineer**
 

--- a/templates/resume.latex
+++ b/templates/resume.latex
@@ -1,0 +1,85 @@
+\documentclass[10pt,letterpaper]{extarticle}
+
+% ---- Page geometry ----
+\usepackage[margin=0.6in,top=0.5in,bottom=0.55in]{geometry}
+
+% ---- Fonts (TeX Gyre Heros = metric-compatible Helvetica, works with pdflatex) ----
+\usepackage[T1]{fontenc}
+\usepackage[utf8]{inputenc}
+\usepackage{tgheros}
+\renewcommand{\familydefault}{\sfdefault}
+
+% ---- Color ----
+\usepackage{xcolor}
+\definecolor{accent}{HTML}{1F6F8B}
+\definecolor{muted}{HTML}{5A5A5A}
+
+% ---- Links ----
+\usepackage[hidelinks]{hyperref}
+\hypersetup{colorlinks=true, urlcolor=accent, linkcolor=accent, breaklinks=true}
+
+% ---- Section styling ----
+\usepackage{titlesec}
+
+% Level 1 (#) - the name banner, used once at the top of the document
+\titleformat{\section}
+  {\flushleft\fontsize{22}{24}\selectfont\bfseries\color{accent}}
+  {}{0em}{}
+\titlespacing*{\section}{0pt}{0pt}{2pt}
+
+% Level 3 (###) - main resume sections: Introduction, Experience, Technical Proficiencies
+\titleformat{\subsubsection}
+  {\flushleft\large\bfseries\color{accent}}
+  {}{0em}
+  {\uppercase}
+  [{\titlerule[0.8pt]}]
+\titlespacing*{\subsubsection}{0pt}{13pt}{5pt}
+
+% Level 4 (####) - sub-groups: Certifications, Cloud, Programming, Networking, ...
+% [block] overrides \paragraph's default run-in shape, which otherwise runs the
+% heading into whatever follows (e.g. shoving a table sideways).
+\titleformat{\paragraph}[block]
+  {\flushleft\normalsize\bfseries\color{muted}}
+  {}{0em}{}
+\titlespacing*{\paragraph}{0pt}{9pt}{3pt}
+
+% ---- Paragraph spacing (tight, resume-style) ----
+\usepackage{parskip}
+\setlength{\parskip}{2.5pt}
+\setlength{\parindent}{0pt}
+
+% ---- Lists ----
+\usepackage{enumitem}
+\setlist[itemize]{leftmargin=1.3em, itemsep=1pt, topsep=2pt, parsep=0pt, partopsep=0pt, label=\textbullet}
+
+% ---- Bold text carries the accent color (job titles, labels, tagline) ----
+\let\oldtextbf\textbf
+\renewcommand{\textbf}[1]{{\color{accent}\oldtextbf{#1}}}
+
+% ---- Tables (proficiency tables) ----
+\usepackage{longtable,booktabs,array}
+\makeatletter
+\@ifundefined{c@none}{\newcounter{none}}{}
+\makeatother
+\renewcommand{\arraystretch}{1.2}
+\setlength{\LTpre}{4pt}
+\setlength{\LTpost}{4pt}
+% longtable centers itself by default (\LTleft/\LTright both default to \fill) - force flush left instead
+\setlength{\LTleft}{0pt}
+\setlength{\LTright}{\fill}
+
+% ---- Footer: just a quiet page number ----
+\usepackage{fancyhdr}
+\pagestyle{fancy}
+\fancyhf{}
+\fancyfoot[C]{\small\color{muted}\thepage}
+\renewcommand{\headrulewidth}{0pt}
+\renewcommand{\footrulewidth}{0pt}
+
+\setlength{\emergencystretch}{3em}
+\providecommand{\tightlist}{\setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
+\sloppy
+
+\begin{document}
+$body$
+\end{document}


### PR DESCRIPTION
The default pandoc export of resume.md looked rough as a PDF (loose spacing, no visual hierarchy, indented skill tables). Add a custom LaTeX template with a clean modern layout (accent-colored sections, tight spacing, left-aligned proficiency tables) and wire it up via `just resume`, which interactively prompts for a phone number so the real number never lands in the committed markdown.

Also tidies the hidden contact block in resume.md into a single line and fixes some stale job history details.

I also fixed up some theming for the Resume page and updated details for it.